### PR TITLE
A rota '/emendas' agora também retorna emendas filtradas

### DIFF
--- a/app/api/emenda.js
+++ b/app/api/emenda.js
@@ -3,12 +3,20 @@ module.exports = function(app){
 
     //Lista todas as Emendas.
     api.getEmenda = (req, res) => {
+        let { num_emenda } = req.query;
+
         const connection = app.conexao.conexao();
         const emendaDAO = new app.infra.EmendaDAO(connection);
 
-        emendaDAO.getEmenda((erro, resultado) => {
-            erro ? (console.log(erro), res.status(500).send('Erro ao obter as emendas.')) : res.status(200).json(resultado);
-        });
+        if(num_emenda){
+            emendaDAO.getEmendaByNumEmenda(num_emenda, (erro, resultado) => {
+                erro ? (console.log(erro), res.status(500).send('Erro ao obter as emendas.')) : res.status(200).json(resultado);
+            });
+        } else {
+            emendaDAO.getEmenda((erro, resultado) => {
+                erro ? (console.log(erro), res.status(500).send('Erro ao obter as emendas.')) : res.status(200).json(resultado);
+            });
+        }
 
         connection.end();
     }

--- a/app/infra/EmendaDAO.js
+++ b/app/infra/EmendaDAO.js
@@ -10,7 +10,18 @@ class EmendaDAO {
             FROM emenda
             INNER JOIN autor ON emenda.cod_autor = autor.cod_autor
             LEFT JOIN status ON emenda.cod_status = status.cod_status
-            ORDER BY emenda.ano DESC`, callback);
+            ORDER BY num_emenda`, callback);
+    }
+
+    //Lista todas as Emendas.
+    getEmendaByNumEmenda(num_emenda, callback) {
+        this._connection.query(
+            `SELECT emenda.cod_emenda, emenda.ano, emenda.num_emenda, emenda.beneficiario, emenda.valor_emenda, autor.*, status.descricao AS status
+            FROM emenda
+            INNER JOIN autor ON emenda.cod_autor = autor.cod_autor
+            LEFT JOIN status ON emenda.cod_status = status.cod_status
+            WHERE emenda.num_emenda LIKE '%${num_emenda}%'
+            ORDER BY num_emenda`, callback);
     }
 
     //Lista uma Emenda com base no ID (cod_emenda).


### PR DESCRIPTION
Atualização na rota "/emendas":
Agora é possível receber como parâmetro o número da emendas, permitindo assim que a lista de emenda seja filtrada com base no número da emenda.
Se nada for passado será retornado todas a lista de Emendas, caso contrario retornará uma lista que contenha o valor do parâmetro em qualquer parte do número da emenda.