### PR TITLE
Rotas para cadastrar, atualizar e apagar legislação

### DIFF
--- a/app/api/legislacao.js
+++ b/app/api/legislacao.js
@@ -1,6 +1,7 @@
 module.exports = function(app){
     let api = {};
 
+    //Lista todas as Legislações.
     api.getLegislacao = (req, res) => {
         const connection = app.conexao.conexao();
         const legislacaoDAO = new app.infra.LegislacaoDAO(connection);
@@ -12,6 +13,7 @@ module.exports = function(app){
         connection.end();
     }
 
+    //Lista uma Legislação com base no ID (ano).
     api.getLegislacaoById = (req, res) => {
         let { ano } = req.params;
 
@@ -23,6 +25,69 @@ module.exports = function(app){
         });
 
         connection.end();
+    }
+
+    //Salva uma nova Legislação.
+    api.postLegislacao = (req, res) => {
+        let legislacao = req.body;
+        
+    	const knex = app.conexao.conexaoKnex();
+
+        knex('legislacao').insert(legislacao)
+            .then(resultado => {
+                knex.destroy();
+                res.status(201).json(resultado[0]);
+            })
+            .catch(erro => {
+                console.log(erro);
+                knex.destroy();
+                if(erro.errno == 1062){
+                    res.status(500).send(`A legislação do ano ${legislacao.ano} já está cadastrada.`);
+                } else {
+                    res.status(500).send('Erro ao cadastrar a legislação.');
+                }
+            });
+    };
+
+    //Atualiza uma Legislação.
+    api.putLegislacao = (req, res) => {
+        const { ano } = req.params;
+        let legislacao = req.body;
+        
+        const knex = app.conexao.conexaoKnex();
+
+        knex('legislacao').update(legislacao).where('ano', ano)
+            .then(resultado => {
+                knex.destroy();
+                res.status(200).end();
+            })
+            .catch(erro => {
+                console.log(erro);
+                knex.destroy();
+                res.status(500).send('Erro ao atualizar a legislação.');
+            });        
+    }
+
+    //Apaga uma Legislação.
+    api.deleteLegislacao = (req, res) => {
+        const { ano } = req.params;
+        
+        const knex = app.conexao.conexaoKnex();
+
+        knex('legislacao').where('ano', ano).delete()
+            .then(resultado => {
+                knex.destroy();
+                res.status(200).end();
+            })
+            .catch(erro => {
+                console.log(erro);
+                knex.destroy();
+                if(erro.errno == 1451){
+                    res.status(500).send('Esta legislação já está vinculada a uma emenda, por isso não pode ser apagada.');
+                } else {
+                    res.status(500).send('Erro ao apagar a legislação.');
+                }
+            });        
     }
 
     return api;

--- a/app/routes/routes.js
+++ b/app/routes/routes.js
@@ -47,10 +47,13 @@ module.exports = function(app){
 
 /* ===== Rotas de Legislação ===== */
     app.route('/legislacoes')
-        .get(legislacao.getLegislacao);
+        .get(legislacao.getLegislacao)
+        .post(legislacao.postLegislacao);
 
     app.route('/legislacoes/:ano')
-        .get(legislacao.getLegislacaoById);
+        .get(legislacao.getLegislacaoById)
+        .put(legislacao.putLegislacao)
+        .delete(legislacao.deleteLegislacao);
 
 /* ===== Rotas de Modalidade ===== */
     app.route('/modalidades')


### PR DESCRIPTION
Novas rotas de legislação disponíveis:
POST: '/legislacoes' para cadastrar uma nova legislação;
PUT: '/legislacoes/:id' para atualizar uma legislação;
DELETE: '/legislacoes/:id' para apagar uma legislação.